### PR TITLE
Update Pravega config properties.

### DIFF
--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -61,14 +61,23 @@ options:
   controller.service.asyncTaskPoolSize: "20"
   controller.retention.threadCount: "4"
   log.level: "INFO"
-  metrics.dynamicCacheSize: "100000"
-  metrics.enableStatistics: "true"
-  metrics.enableStatsDReporter: "false"
-  metrics.statsdHost: "telegraph.default"
-  metrics.statsdPort: "8125"
-  metrics.enableInfluxDBReporter: "true"
-  metrics.outputFrequencySeconds: "10"
-  metrics.influxDBURI: "http://192.168.219.30:8086"
+
+  # Doc update: https://github.com/pravega/pravega/pull/4862/files
+
+  # metrics.dynamicCacheSize: "100000"
+  
+  metrics.statistics.enable: "true"
+  # statsD metrics config
+  metrics.statsD.reporter.enable: "true"
+  metrics.statsD.connect.host: "telegraph.default"
+  metrics.statsD.connect.port: "8125"
+  # Influx DB Metrics config
+  metrics.influxDB.reporter.enable: "true"
+  metrics.influxDB.connect.uri: "http://192.168.219.30:8086"
+  metrics.influxDB.connect.db.name: "pravega"
+  metrics.influxDB.retention: "two_hour"
+  metrics.output.frequency.seconds: "10"
+
   controller.metrics.dynamicCacheSize: "100000"
   controller.metrics.enableStatistics: "true"
   controller.metrics.enableStatsDReporter: "false"

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -17,7 +17,7 @@ bookkeeperUri: "pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.clust
 
 pravega:
   image:
-    repository: devops-repo.isus.emc.com:8116/nautilus/nautilus-pravega
+    repository: andreykoltsov/pravega
     tag: 0.8.0-2539.d84a68cc5-1.2-dev-000.5b852dd
   controllerReplicas: 1
   segmentStoreReplicas: 3
@@ -64,8 +64,7 @@ options:
 
   # Doc update: https://github.com/pravega/pravega/pull/4862/files
 
-  # metrics.dynamicCacheSize: "100000"
-  
+  metrics.dynamicCache.size: "100000"
   metrics.statistics.enable: "true"
   # statsD metrics config
   metrics.statsD.reporter.enable: "true"
@@ -73,16 +72,21 @@ options:
   metrics.statsD.connect.port: "8125"
   # Influx DB Metrics config
   metrics.influxDB.reporter.enable: "true"
-  metrics.influxDB.connect.uri: "http://192.168.219.30:8086"
+  metrics.influxDB.connect.uri: "localhost:8086"
   metrics.influxDB.connect.db.name: "pravega"
   metrics.influxDB.retention: "two_hour"
   metrics.output.frequency.seconds: "10"
 
-  controller.metrics.dynamicCacheSize: "100000"
-  controller.metrics.enableStatistics: "true"
-  controller.metrics.enableStatsDReporter: "false"
-  controller.metrics.statsdHost: "telegraph.default"
-  controller.metrics.statsdPort: "8125"
-  controller.metrics.enableInfluxDBReporter: "true"
-  controller.metrics.outputFrequencySeconds: "10"
-  controller.metrics.influxDBURI: "http://192.168.219.30:8086"
+  # Controller metrics
+  controller.metrics.dynamicCache.size: "100000"
+  controller.metrics.statistics.enable: "true"
+  # statsD metrics config
+  controller.metrics.statsD.reporter.enable: "true"
+  controller.metrics.statsD.connect.host: "telegraph.default"
+  controller.metrics.statsD.connect.port: "8125"
+  # Influx DB Metrics config
+  controller.metrics.influxDB.reporter.enable: "true"
+  controller.metrics.influxDB.connect.uri: "localhost:8086"
+  controller.metrics.influxDB.connect.db.name: "pravega"
+  controller.metrics.influxDB.retention: "two_hour"
+  controller.metrics.output.frequency.seconds: "10"


### PR DESCRIPTION
### Change log description

1. Update configuration properties names;
2. Add missing DB name into InfluxDB options;

Since https://github.com/pravega/pravega/commit/efa9e08b205c6c45631b5bd3b492514eeae36421, Pravega has new configration property names. Even though backward compatibility is supported, it's always better to keep the configuration up to date.

### Purpose of the change

Prevents issues regarding metrics export.

### What the code does

Updates PravegaCluster properties.

### How to verify it

1. Deploy Influx DB
2. Deplyo PravegaCluster. Keep in mind Influx DB address and name have to be set with respect to the actual address and schema. It could be set via `--set` flag.
3. Send load onto PravegaCluster using any load generator.
4. Check metrics within Influx DB deployed in p. 1